### PR TITLE
fixed compile error

### DIFF
--- a/src/nooliterx.c
+++ b/src/nooliterx.c
@@ -227,7 +227,8 @@ int main(int argc, char * argv[])
                 {
 					char repstr[255];
 					static char *searchfor[8] = {"%st", "%ch", "%cm", "%df", "%d0", "%d1", "%d2", "%d3"};
-					for (int k=0; k<8; k++)
+					int k;
+					for (k=0; k<8; k++)
 					{
 						int incr = 0;
 						if (k == 1)

--- a/src/nooliterxcfg.c
+++ b/src/nooliterxcfg.c
@@ -52,7 +52,7 @@ int main(int argc, char * argv[])
         
         if (argc == 2) // no channel number expected
         {
-            if ((strcmp(argv[1], "--bind") == 0) || (strcmp(argv[1], "--clear")))
+            if ((strcmp(argv[1], "--bind") == 0) || (strcmp(argv[1], "--clear") == 0))
             {
                 printf("No channel number given.\n");
                 usage();


### PR DESCRIPTION
fixed "for loop initial declarations are only allowed in C99 mode" error:
nooliterx.c:230:6: error: ‘for’ loop initial declarations are only allowed in C99 mode
nooliterx.c:230:6: note: use option -std=c99 or -std=gnu99 to compile your code

Почему-то не собиралось на wirenboard(debian, arm). Теперь собирается. 

исправил ошибку, которая не давала выполнить команду "--clearall", говоря "No channel number given."
